### PR TITLE
Fix navbar overlay behavior

### DIFF
--- a/trello-frontend/src/app/modules/layout/components/navbar/navbar.component.html
+++ b/trello-frontend/src/app/modules/layout/components/navbar/navbar.component.html
@@ -28,7 +28,7 @@
               cdkConnectedOverlay
               [cdkConnectedOverlayOrigin]="espacioOverlay"
               [cdkConnectedOverlayOpen]="isOpenEspaciodeTrabajo"
-              (overlayOutsideClick)="isOpenEspaciodeTrabajo = !isOpenEspaciodeTrabajo"
+              (overlayOutsideClick)="isOpenEspaciodeTrabajo = false"
             >
               <div
                 class="z-50 my-4 w-60 text-base list-none bg-white border border-gray-100 rounded-lg shadow-lg p-4"
@@ -102,9 +102,9 @@
             </a>
             <ng-template
               cdkConnectedOverlay
-              [cdkConnectedOverlayOrigin]="espacioOverlay"
+              [cdkConnectedOverlayOrigin]="recienteOverlay"
               [cdkConnectedOverlayOpen]="isOpenReciente"
-              (overlayOutsideClick)="isOpenReciente = !isOpenReciente"
+              (overlayOutsideClick)="isOpenReciente = false"
             >
               <div
                 class="z-50 my-4 w-60 text-base list-none bg-white border border-gray-100 rounded-lg shadow-lg p-2"
@@ -199,7 +199,7 @@
           cdkConnectedOverlay
           [cdkConnectedOverlayOrigin]="perfilOverlay"
           [cdkConnectedOverlayOpen]="isOpen"
-          (overlayOutsideClick)="isOpen = !isOpen"
+        (overlayOutsideClick)="isOpen = false"
 
         >
           <div


### PR DESCRIPTION
## Summary
- keep dropdowns closed on outside click
- anchor "Reciente" overlay to its own button

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842243449088331b6bbaff66f783d27